### PR TITLE
Update GoogleMembershipService.java to try/check the lastName method

### DIFF
--- a/src/main/java/edu/ucsb/cs56/w20/lab07/services/GoogleMembershipService.java
+++ b/src/main/java/edu/ucsb/cs56/w20/lab07/services/GoogleMembershipService.java
@@ -118,7 +118,12 @@ public class GoogleMembershipService implements MembershipService {
     public String lastName(OAuth2AuthenticationToken token) {
         if (token == null)
             return "";
-        return token.getPrincipal().getAttributes().get("family_name").toString();
+        try {
+            return token.getPrincipal().getAttributes().get("family_name").toString();
+        }
+        catch(NullPointerException e) {
+            return "";
+        }   
     }
 
     public String email(OAuth2AuthenticationToken token) {


### PR DESCRIPTION
Updated the GoogleMembershipService class's lastName method. The GoogleAPI returns a nullptr, rather than an empty string if a last name doesn't exist. This could cause NullPtrExceptions, leading to crashes. Thus, we just use a try/catch block to account for this edge case.