### PR TITLE
pc - temporarily comment out jacoco in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -170,7 +170,7 @@
 			</plugin>
 
 			<!-- Test case coverage report -->
-			<plugin>
+			<!-- <plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
 				<version>0.8.2</version>
@@ -188,7 +188,7 @@
 						</goals>
 					</execution>
 				</executions>
-			</plugin>
+			</plugin> -->
 
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
There is currently an unknown bug that is causing mvn test to fail
with jacoco enabled in the pom.xml.  Until we can determine what is
causing that, we need to remove jacoco.    That will enable students
to make progress with the project while still having test coverage
on GitHub actions.